### PR TITLE
Script for batch updates to CSPROJ files

### DIFF
--- a/csproj-bulk-edit.ps1
+++ b/csproj-bulk-edit.ps1
@@ -1,11 +1,11 @@
 param (
-    [string][Parameter(Mandatory=$true, Position = 1)]$folder = ".",
-    [string][Parameter(Mandatory=$true, Position = 2)]$property = $(throw "You must specify a property and a value to set for csproj files."),
-    [string][Parameter(Mandatory=$true, Position = 3)]$value = $(throw "You must specify a property and a value to set for csproj files.")
+    [string][AllowNull()][Parameter(Position = 1)]$folder = ".",
+    [string][AllowNull()][Parameter(Position = 2)]$property,
+    [string][AllowNull()][Parameter(Position = 3)]$value
 )
 
 function Usage() {
-    Write-Output
+    Write-Output ""
     Write-Output "Usage:"
     Write-Output "    csproj-bulk-edit <folder> <property> <value>"
     Write-Output ""
@@ -17,7 +17,7 @@ function Usage() {
 }
 
 # Does this folder exist?
-if (-not (Test-Path -Path $folder)) {
+if (!$folder -or -not (Test-Path -Path $folder)) {
     Write-Output "The folder '${folder}' doesn't exist."
     Usage
 }

--- a/ensure-warnings-as-errors.ps1
+++ b/ensure-warnings-as-errors.ps1
@@ -12,6 +12,20 @@ if (Test-Path -Path $folderspec) {
         $xml.PreserveWhitespace = $true
         $xml.Load($path)
 
+        # What does this look like?
+        # # Function to recursively traverse and print nodes
+        # function Get-XmlNodes($node) {
+        #     if ($node.GetType().FullName -eq "System.Xml.XmlWhitespace") {
+        #         Write-Host "Whitespace: '$($node.OuterXml)'"
+        #     }
+        #     foreach ($child in $node.ChildNodes) {
+        #         Get-XmlNodes $child
+        #     }
+        # }
+
+        # # Start with the root node
+        # Get-XmlNodes $xml.DocumentElement
+
         # We can only proceed if there's a single property group within the csproj file
         $propertyGroups = $xml.SelectNodes("//Project/PropertyGroup")
         if ($propertyGroups.Count -ne 1) {
@@ -22,15 +36,16 @@ if (Test-Path -Path $folderspec) {
             $node = $propertyGroups[0].SelectSingleNode($key)
             if ($node) {
                 Write-Output "The file '${path}' has project property group ${key} set to '${value}'"
+                Write-Output "Outer XML is '$($node.OuterXml)'"
             } else {
                 Write-Output "File [${path}]: Setting project property group ${key} to '${value}'"
 
                 # Construct the node with indentation before it, and a newline after it, so it looks appealing within the overall csproj file
-                $newNodeText = "  <" + $key + ">" + $value + "</" + $key + ">`n  "
+                $newNodeText = "`n<" + $key + ">" + $value + "</" + $key + ">`n"
                 $newNode = $xml.CreateDocumentFragment()
                 $newNode.InnerXml = $newNodeText
                 # We must save the results of this method call to a variable; otherwise it prints the function result to the console which looks ugly
-                $newChild = $xml.Project.PropertyGroup.AppendChild($newNode)
+                _ = $xml.Project.PropertyGroup.AppendChild($newNode)
                 $xml.Save($path)
             }
         }

--- a/ensure-warnings-as-errors.ps1
+++ b/ensure-warnings-as-errors.ps1
@@ -1,0 +1,33 @@
+# Run this script with arg[0] = the folder where you want to search for csproj files
+$folderspec = $args[0]
+$key = $args[1]
+$value = $args[2]
+
+# Review all files in this folder and child folders
+if (Test-Path -Path $folderspec) {
+    foreach ($path in Get-ChildItem -Recurse "${folderspec}/**/*.csproj") {
+        $xml = [xml]::new()
+        $xml.PreserveWhitespace = $true
+        $xml.Load($path)
+        $node = $xml | Select-Xml -XPath "//Project/PropertyGroup/${key}"
+        if ($node) {
+            Write-Output "The file '${path}' has project property group ${key} set to '${value}'"
+        } else {
+            Write-Output "File [${path}]: Setting project property group ${key} to '${value}'"
+
+            # Construct the node with indentation before it, and a newline after it, so it looks appealing within the overall csproj file
+            $newNodeText = "  <" + $key + ">" + $value + "</" + $key + ">`n  "
+            Write-Output "1"
+            $newNode = $xml.CreateDocumentFragment()
+            Write-Output "2"
+            $newNode.InnerXml = $newNodeText
+            Write-Output "3"
+            $newChild = $xml.Project.PropertyGroup.AppendChild($newNode)
+            Write-Output "4"
+            $xml.Save($path)
+            Write-Output "5"
+        }
+    }
+} else {
+    Write-Output "The folder ${folderspec} doesn't exist."
+}

--- a/ensure-warnings-as-errors.ps1
+++ b/ensure-warnings-as-errors.ps1
@@ -6,26 +6,33 @@ $value = $args[2]
 # Review all files in this folder and child folders
 if (Test-Path -Path $folderspec) {
     foreach ($path in Get-ChildItem -Recurse "${folderspec}/**/*.csproj") {
+
+        # Load XML using "preserve whitespace" so we can avoid unnecessary github changes
         $xml = [xml]::new()
         $xml.PreserveWhitespace = $true
         $xml.Load($path)
-        $node = $xml | Select-Xml -XPath "//Project/PropertyGroup/${key}"
-        if ($node) {
-            Write-Output "The file '${path}' has project property group ${key} set to '${value}'"
-        } else {
-            Write-Output "File [${path}]: Setting project property group ${key} to '${value}'"
 
-            # Construct the node with indentation before it, and a newline after it, so it looks appealing within the overall csproj file
-            $newNodeText = "  <" + $key + ">" + $value + "</" + $key + ">`n  "
-            Write-Output "1"
-            $newNode = $xml.CreateDocumentFragment()
-            Write-Output "2"
-            $newNode.InnerXml = $newNodeText
-            Write-Output "3"
-            $newChild = $xml.Project.PropertyGroup.AppendChild($newNode)
-            Write-Output "4"
-            $xml.Save($path)
-            Write-Output "5"
+        # We can only proceed if there's a single property group within the csproj file
+        $propertyGroups = $xml.SelectNodes("//Project/PropertyGroup")
+        if ($propertyGroups.Count -ne 1) {
+            Write-Output "There are $($propertyGroups.Count) property groups in the file '${path}'; cannot edit"
+        } else {
+
+            # Look for that property within this property group
+            $node = $propertyGroups[0].SelectSingleNode($key)
+            if ($node) {
+                Write-Output "The file '${path}' has project property group ${key} set to '${value}'"
+            } else {
+                Write-Output "File [${path}]: Setting project property group ${key} to '${value}'"
+
+                # Construct the node with indentation before it, and a newline after it, so it looks appealing within the overall csproj file
+                $newNodeText = "  <" + $key + ">" + $value + "</" + $key + ">`n  "
+                $newNode = $xml.CreateDocumentFragment()
+                $newNode.InnerXml = $newNodeText
+                # We must save the results of this method call to a variable; otherwise it prints the function result to the console which looks ugly
+                $newChild = $xml.Project.PropertyGroup.AppendChild($newNode)
+                $xml.Save($path)
+            }
         }
     }
 } else {

--- a/ensure-warnings-as-errors.ps1
+++ b/ensure-warnings-as-errors.ps1
@@ -49,6 +49,7 @@ if (Test-Path -Path $folderspec) {
 
                 # Preserve original file contents in case warnings-as-errors breaks this build
                 $original = Get-Content $path
+                Rename-Item -Path $path -NewName "${path}.old"
 
                 # Construct the node with indentation before it, and a newline after it, so it looks appealing within the overall csproj file
                 # Note that we don't need a newline beforehand, for some reason the preserve whitespace option would cause it to be a duplicate
@@ -65,9 +66,12 @@ if (Test-Path -Path $folderspec) {
                 $buildResults = & dotnet build $path 
                 if ($?) {
                     Write-Output "Successfully built ${path} with new setting ${key} to '${value}'"
+                    Remove-Item "${path}.old"
                 } else {
                     Write-Output "Unable to build ${path} with the updated property setting, reverting change."
                     Set-Content -Path $path $original
+                    Remove-Item $path
+                    Rename-Item -Path "${path}.old" -NewName $path
                 }
             }
         }

--- a/ensure-warnings-as-errors.ps1
+++ b/ensure-warnings-as-errors.ps1
@@ -32,6 +32,31 @@ if (Test-Path -Path $folderspec) {
             Write-Output "There are $($propertyGroups.Count) property groups in the file '${path}'; cannot edit"
         } else {
 
+            # Try to figure out the maximum indentation level of children beneath this node, guessing 4 as default
+            $spacesBeforeElement = 4
+            foreach ($whitespace in $propertyGroups[0].ChildNodes) {
+                if ($whitespace.GetType().FullName -eq "System.Xml.XmlWhitespace") {
+                    $str = $whitespace.OuterXml.ToString()
+                    $spaces = 0
+                    foreach ($char in $str.ToCharArray()) {
+                        if ($char -eq " ") {
+                            $spaces = $spaces + 1
+                        }
+                    }
+                    if ($spacesBeforeElement -lt $spaces) {
+                        $spacesBeforeElement = $spaces
+                    }
+                    Write-Output "String length: $($str.length) Spaces: ${spaces}"
+                }
+            }
+
+            # We are at level two: Project is at the root, PropertyGroup is at level one, and the new item we're adding is at level two
+            # So we want to determine the number-of-spaces by dividing spacesBeforeElement by two
+            Write-Output "Using ${spacesBeforeElement} spaces per indentation level"
+            $spacesBeforeElement = $spacesBeforeElement / 2
+            Write-Output "Using ${spacesBeforeElement} spaces per indentation level"
+            $indentation = [string]::new(' ', $spacesBeforeElement)
+
             # Look for that property within this property group
             $node = $propertyGroups[0].SelectSingleNode($key)
             if ($node) {
@@ -41,11 +66,13 @@ if (Test-Path -Path $folderspec) {
                 Write-Output "File [${path}]: Setting project property group ${key} to '${value}'"
 
                 # Construct the node with indentation before it, and a newline after it, so it looks appealing within the overall csproj file
-                $newNodeText = "`n<" + $key + ">" + $value + "</" + $key + ">`n"
+                # Note that we don't need a newline beforehand, for some reason the preserve whitespace option would cause it to be a duplicate
+                # Note that the previous whitespace element would already have indented us once
+                $newNodeText = "${indentation}<" + $key + ">" + $value + "</" + $key + ">`n${indentation}"
                 $newNode = $xml.CreateDocumentFragment()
                 $newNode.InnerXml = $newNodeText
                 # We must save the results of this method call to a variable; otherwise it prints the function result to the console which looks ugly
-                _ = $xml.Project.PropertyGroup.AppendChild($newNode)
+                $_ = $xml.Project.PropertyGroup.AppendChild($newNode)
                 $xml.Save($path)
             }
         }


### PR DESCRIPTION
Let's draft a little PowerShell script for doing bulk changes to csproj files.

Specifically, I'd like the ability to modify configuration values for csproj files in bulk like this:

```
.\ensure-warnings-as-errors.ps1 /folder/path/ TreatWarningsAsErrors true
```

The idea is that this script would do the following:
1) Read all csproj files in /folder/path
2) Attempt to set the value `<Project><PropertyGroup><TreatWarningsAsErrors>` to the value `true`
3) If it is able to set the value, try compiling the project
4) If the project fails to compile, undo the change; if the compile succeeds, save the change to disk.